### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ Example to show streaming heartrate from watch using Swift
 - queary from healthkit to show heartrate
 
 
-##Requirements
+## Requirements
 
 - Xcode 7.0, iOS 9.0 SDK, watchOS 2.0 SDK
 - iOS 9.0 and watchOS 2.0
 
-##How to build
+## How to build
 
 - Change the "Team" setting on [General] for each target.
 - Setup HealthKit for the WatchKit extension target.
 
-##watchOS Beta3 
+## watchOS Beta3 
 
 - Simulator now showing simulated heartrate 
 
-##watchOS Beta4
+## watchOS Beta4
 
 - Updated with new APIs 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
